### PR TITLE
feat(eip)!: make eipPublicIp required for EipAttributes

### DIFF
--- a/API.md
+++ b/API.md
@@ -1177,7 +1177,7 @@ The allocation ID.
 
 ---
 
-##### `eipPublicIp`<sup>Optional</sup> <a name="eipPublicIp" id="@ogis-rd/awscdk-nat-lib.EipAttributes.property.eipPublicIp"></a>
+##### `eipPublicIp`<sup>Required</sup> <a name="eipPublicIp" id="@ogis-rd/awscdk-nat-lib.EipAttributes.property.eipPublicIp"></a>
 
 ```typescript
 public readonly eipPublicIp: string;

--- a/src/eip.ts
+++ b/src/eip.ts
@@ -36,7 +36,7 @@ export interface EipAttributes {
   /**
    * The Elastic IP address.
    */
-  readonly eipPublicIp?: string;
+  readonly eipPublicIp: string;
 }
 
 abstract class EipBase extends core.Resource implements IEip {
@@ -56,14 +56,7 @@ export class Eip extends EipBase {
   public static fromEipAttributes(scope: Construct, id: string, attrs: EipAttributes): IEip {
     class Import extends EipBase {
       public readonly eipAllocationId = attrs.eipAllocationId;
-      private readonly _eipPublicIp = attrs.eipPublicIp;
-
-      public get eipPublicIp() {
-        if (!this._eipPublicIp) {
-          throw new Error('eipPublicIp is not provided for the imported Eip.');
-        }
-        return this._eipPublicIp;
-      };
+      public readonly eipPublicIp = attrs.eipPublicIp;
     }
     return new Import(scope, id);
   }

--- a/test/default-public-nat-gateway.test.ts
+++ b/test/default-public-nat-gateway.test.ts
@@ -50,6 +50,7 @@ describe('DefaultPublicNatGateway', () => {
   test('create with existing EIP', () => {
     const eip = Eip.fromEipAttributes(stack, 'Eip', {
       eipAllocationId: 'eipalloc-123456789abcdefgh',
+      eipPublicIp: '1.2.3.4',
     });
 
     new DefaultPublicNatGateway(stack, 'DefaultPublicNatGateway', {

--- a/test/eip.test.ts
+++ b/test/eip.test.ts
@@ -38,23 +38,6 @@ describe('EIP', () => {
     template.resourceCountIs('AWS::EC2::EIP', 0);
   });
 
-  test('import without eipPublicIp', () => {
-    const attributes: EipAttributes = {
-      eipAllocationId: 'eipalloc-123456789abcdefgh',
-    };
-    const eip = Eip.fromEipAttributes(stack, 'Eip', attributes);
-
-    expect(Eip.isEip(eip)).toBe(false);
-    expect(eip.eipAllocationId).toBe(attributes.eipAllocationId);
-    expect(() => {
-      eip.eipPublicIp;
-    }).toThrow('eipPublicIp is not provided for the imported Eip.');
-
-    const template = Template.fromStack(stack);
-
-    template.resourceCountIs('AWS::EC2::EIP', 0);
-  });
-
   test('import with allocation ID', () => {
     const allocationId = 'eipalloc-123456789abcdefgh';
 

--- a/test/nat-gateway.test.ts
+++ b/test/nat-gateway.test.ts
@@ -59,6 +59,7 @@ describe('PublicNatGateway', () => {
   test('create with existing EIP', () => {
     const eip = Eip.fromEipAttributes(stack, 'Eip', {
       eipAllocationId: 'eipalloc-123456789abcdefgh',
+      eipPublicIp: '1.2.3.4',
     });
 
     new PublicNatGateway(stack, 'PublicNatGateway', {


### PR DESCRIPTION
### Related Issues

Fixes #5

### Description

Make the `eipPublicIp` property required.
<!--
Describe concisely your pull request and provide some background information, for example:

* Motivation
* Design
* Testing
-->

### Checklist

* [x] My contribution adheres to the [Contributing Guidelines](https://github.com/ogis-rd/awscdk-nat-lib/blob/main/CONTRIBUTING.md)

### Other

To create an unowned EIP object with just an allocation ID, use the dedicated method [`fromAllocationId`](https://github.com/ogis-rd/awscdk-nat-lib/pull/6) instead.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.
