### PR TITLE
chore(deps): bump projen from 0.91.30 to 0.93.3

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,88 +44,80 @@
     "!projenrc/**/*.ts"
   ],
   "rules": {
-    "indent": [
-      "off"
-    ],
     "@stylistic/indent": [
       "error",
       2
     ],
-    "quotes": [
+    "@stylistic/quotes": [
       "error",
       "single",
       {
         "avoidEscape": true
       }
     ],
-    "comma-dangle": [
+    "@stylistic/comma-dangle": [
       "error",
       "always-multiline"
     ],
-    "comma-spacing": [
+    "@stylistic/comma-spacing": [
       "error",
       {
         "before": false,
         "after": true
       }
     ],
-    "no-multi-spaces": [
+    "@stylistic/no-multi-spaces": [
       "error",
       {
         "ignoreEOLComments": false
       }
     ],
-    "array-bracket-spacing": [
+    "@stylistic/array-bracket-spacing": [
       "error",
       "never"
     ],
-    "array-bracket-newline": [
+    "@stylistic/array-bracket-newline": [
       "error",
       "consistent"
     ],
-    "object-curly-spacing": [
+    "@stylistic/object-curly-spacing": [
       "error",
       "always"
     ],
-    "object-curly-newline": [
+    "@stylistic/object-curly-newline": [
       "error",
       {
         "multiline": true,
         "consistent": true
       }
     ],
-    "object-property-newline": [
+    "@stylistic/object-property-newline": [
       "error",
       {
         "allowAllPropertiesOnSameLine": true
       }
     ],
-    "keyword-spacing": [
+    "@stylistic/keyword-spacing": [
       "error"
     ],
-    "brace-style": [
+    "@stylistic/brace-style": [
       "error",
       "1tbs",
       {
         "allowSingleLine": true
       }
     ],
-    "space-before-blocks": [
+    "@stylistic/space-before-blocks": [
       "error"
-    ],
-    "curly": [
-      "error",
-      "multi-line",
-      "consistent"
     ],
     "@stylistic/member-delimiter-style": [
       "error"
     ],
-    "semi": [
+    "@stylistic/semi": [
       "error",
       "always"
     ],
-    "max-len": [
+    "@stylistic/max-len": [
       "error",
       {
         "code": 150,
@@ -136,13 +128,25 @@
         "ignoreRegExpLiterals": true
       }
     ],
-    "quote-props": [
+    "@stylistic/quote-props": [
       "error",
       "consistent-as-needed"
     ],
-    "@typescript-eslint/no-require-imports": [
+    "@stylistic/key-spacing": [
       "error"
     ],
+    "@stylistic/no-multiple-empty-lines": [
+      "error"
+    ],
+    "@stylistic/no-trailing-spaces": [
+      "error"
+    ],
+    "curly": [
+      "error",
+      "multi-line",
+      "consistent"
+    ],
+    "@typescript-eslint/no-require-imports": "error",
     "import/no-extraneous-dependencies": [
       "error",
       {
@@ -178,27 +182,12 @@
     "no-shadow": [
       "off"
     ],
-    "@typescript-eslint/no-shadow": [
-      "error"
-    ],
-    "key-spacing": [
-      "error"
-    ],
-    "no-multiple-empty-lines": [
-      "error"
-    ],
-    "@typescript-eslint/no-floating-promises": [
-      "error"
-    ],
+    "@typescript-eslint/no-shadow": "error",
+    "@typescript-eslint/no-floating-promises": "error",
     "no-return-await": [
       "off"
     ],
-    "@typescript-eslint/return-await": [
-      "error"
-    ],
-    "no-trailing-spaces": [
-      "error"
-    ],
+    "@typescript-eslint/return-await": "error",
     "dot-notation": [
       "error"
     ],

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
         run: |-
           git add .
           git diff --staged --patch --exit-code > repo.patch || echo "self_mutation_happened=true" >> $GITHUB_OUTPUT
+        shell: bash
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
         run: |-
           echo "latest_commit=$(git ls-remote origin -h ${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
+        shell: bash
       - name: Backup artifact permissions
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: cd dist && getfacl -R . > permissions-backup.acl

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -29,6 +29,7 @@ jobs:
         run: |-
           git add .
           git diff --staged --patch --exit-code > repo.patch || echo "patch_created=true" >> $GITHUB_OUTPUT
+        shell: bash
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -76,7 +76,7 @@
     },
     {
       "name": "projen",
-      "version": "0.91.30",
+      "version": "0.93.3",
       "type": "build"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -39,7 +39,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
 
   // The last version before lib and cli were split <https://github.com/aws/aws-cdk/issues/32775>
   cdkVersion: '2.179.0',
-  projenVersion: '0.91.30',
+  projenVersion: '0.93.3',
 
   jsiiVersion,
   typescriptVersion: jsiiVersion,

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "jsii-docgen": "^10.5.0",
         "jsii-pacmak": "^1.127.0",
         "jsii-rosetta": "~5.9",
-        "projen": "0.91.30",
+        "projen": "0.93.3",
         "ts-jest": "^29.4.6",
         "ts-node": "^10.9.2",
         "typescript": "~5.9"
@@ -8591,17 +8591,17 @@
       "license": "MIT"
     },
     "node_modules/projen": {
-      "version": "0.91.30",
-      "resolved": "https://registry.npmjs.org/projen/-/projen-0.91.30.tgz",
-      "integrity": "sha512-MJJA5g70PdgCUgk5KTKZfQqKD155ugoTxQtK2sbpU3Kn1GtYqhEvZld7FRxZpYZ0FxugiMiysOhMS+hWkQOZgg==",
+      "version": "0.93.3",
+      "resolved": "https://registry.npmjs.org/projen/-/projen-0.93.3.tgz",
+      "integrity": "sha512-RyMCnL5vAVhPPExYxC9DkY7U95KPu4u3fJ42FX01xu2Cs3wyH0vxZwPIYXeKRl0omS336wEDKNX+CK9M401EMQ==",
       "bundleDependencies": [
         "@iarna/toml",
         "case",
         "chalk",
         "comment-json",
         "conventional-changelog-config-spec",
+        "fast-glob",
         "fast-json-patch",
-        "glob",
         "ini",
         "parse-conflict-json",
         "semver",
@@ -8619,11 +8619,11 @@
         "comment-json": "4.2.2",
         "constructs": "^10.0.0",
         "conventional-changelog-config-spec": "^2.1.0",
+        "fast-glob": "^3.3.3",
         "fast-json-patch": "^3.1.1",
-        "glob": "^8",
         "ini": "^2.0.0",
         "parse-conflict-json": "^4.0.0",
-        "semver": "^7.7.1",
+        "semver": "^7.7.2",
         "shx": "^0.4.0",
         "xmlbuilder2": "^3.1.1",
         "yaml": "^2.2.2",
@@ -8752,35 +8752,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/projen/node_modules/argparse": {
-      "version": "1.0.10",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/projen/node_modules/array-timsort": {
       "version": "1.0.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/projen/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/projen/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
     },
     "node_modules/projen/node_modules/braces": {
       "version": "3.0.3",
@@ -8886,7 +8862,7 @@
       "license": "MIT"
     },
     "node_modules/projen/node_modules/end-of-stream": {
-      "version": "1.4.4",
+      "version": "1.4.5",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9008,18 +8984,6 @@
         "node": ">=8.6.0"
       }
     },
-    "node_modules/projen/node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/projen/node_modules/fast-json-patch": {
       "version": "3.1.1",
       "dev": true,
@@ -9046,12 +9010,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/projen/node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/projen/node_modules/function-bind": {
       "version": "1.1.2",
@@ -9083,35 +9041,16 @@
         "node": ">=6"
       }
     },
-    "node_modules/projen/node_modules/glob": {
-      "version": "8.1.0",
+    "node_modules/projen/node_modules/glob-parent": {
+      "version": "5.1.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "is-glob": "^4.0.1"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/projen/node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">= 6"
       }
     },
     "node_modules/projen/node_modules/has-flag": {
@@ -9143,22 +9082,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/projen/node_modules/inflight": {
-      "version": "1.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/projen/node_modules/inherits": {
-      "version": "2.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/projen/node_modules/ini": {
       "version": "2.0.0",
@@ -9246,19 +9169,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC"
-    },
-    "node_modules/projen/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/projen/node_modules/just-diff": {
       "version": "6.0.2",
@@ -9390,7 +9300,7 @@
       }
     },
     "node_modules/projen/node_modules/pump": {
-      "version": "3.0.2",
+      "version": "3.0.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9502,7 +9412,7 @@
       }
     },
     "node_modules/projen/node_modules/semver": {
-      "version": "7.7.1",
+      "version": "7.7.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9668,6 +9578,28 @@
         "node": ">=12.0"
       }
     },
+    "node_modules/projen/node_modules/xmlbuilder2/node_modules/argparse": {
+      "version": "1.0.10",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/projen/node_modules/xmlbuilder2/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/projen/node_modules/y18n": {
       "version": "5.0.8",
       "dev": true,
@@ -9678,7 +9610,7 @@
       }
     },
     "node_modules/projen/node_modules/yaml": {
-      "version": "2.7.1",
+      "version": "2.8.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9686,7 +9618,7 @@
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
       }
     },
     "node_modules/projen/node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "jsii-docgen": "^10.5.0",
     "jsii-pacmak": "^1.127.0",
     "jsii-rosetta": "~5.9",
-    "projen": "0.91.30",
+    "projen": "0.93.3",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
     "typescript": "~5.9"


### PR DESCRIPTION
As a result of this upgrade, the project changes as outlined below:

* Modernize ESLint configuration: use `@stylistic` rules like `@stylistic/no-multiple-empty-lines` and `@stylistic/no-trailing-spaces`
* Explicitly set the shell to `bash` (`build.yml`, `release.yml`, `upgrade-main.yml`) to ensure the workflows also work on Windows runners by default

### Checklist

* [x] My contribution adheres to the [Contributing Guidelines](https://github.com/ogis-rd/awscdk-nat-lib/blob/main/CONTRIBUTING.md)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.
